### PR TITLE
Add B tag plots

### DIFF
--- a/objectPerformance/cfg_caching/V27_bTagNN.yaml
+++ b/objectPerformance/cfg_caching/V27_bTagNN.yaml
@@ -1,0 +1,10 @@
+V27:
+  TT:
+    ntuple_path: /afs/cern.ch/work/e/ejclemen/TJM/BJetNN/Phase2-L1MenuTools/ntuples_dr4.root
+    trees_branches:
+      genTree/L1GenTree:
+        genMetTrue: "all"
+        jet: "all"
+      l1PhaseIITree/L1PhaseIITree:
+        seededConeExtendedPuppiJet: [Pt, Et, Eta, Phi, BJetNN]
+        seededConePuppiJet: [Pt, Et, Eta, Phi]

--- a/objectPerformance/cfg_plots/V27_bTagNN/bJetEff.yaml
+++ b/objectPerformance/cfg_plots/V27_bTagNN/bJetEff.yaml
@@ -1,0 +1,30 @@
+BJetEff_Pt:
+  files:
+    JetMatching_Pt_Pt30ToInf_genBJets_-999_V27:
+      object: seededConeExtendedPuppiJet
+      dir: outputs/V27/turnons/
+      label: "Signal: Matched b-jets"
+    JetMatching_Pt_Pt30ToInf_genNotBJets_-999_V27:
+      object: seededConeExtendedPuppiJet
+      dir: outputs/V27/turnons/
+      label: "Background: Unmatched b-jets"
+  xlabel: "Gen. $p_T$ (GeV)"
+  ylabel: "Matching Efficiency"
+  watermark: "BJet_Pt"
+  save_dir: "outputs/BJet/turnons"
+
+
+BJetEff_Eta:
+  files:
+    JetMatching_Eta_Pt30ToInf_genBJets_-999_V27:
+      object: seededConeExtendedPuppiJet
+      dir: outputs/V27/turnons/
+      label: "Signal: Matched b-jets"
+    JetMatching_Eta_Pt30ToInf_genNotBJets_-999_V27:
+      object: seededConeExtendedPuppiJet
+      dir: outputs/V27/turnons/
+      label: "Background: Unmatched b-jets"
+  xlabel: "Gen. $\\eta$"
+  ylabel: "Matching Efficiency"
+  watermark: "BJet_Eta"
+  save_dir: "outputs/BJet/turnons"

--- a/objectPerformance/cfg_plots/V27_bTagNN/jets_matching.yaml
+++ b/objectPerformance/cfg_plots/V27_bTagNN/jets_matching.yaml
@@ -1,0 +1,179 @@
+JetMatching_Eta_Pt40To100_ExtendedVsRegular:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Eta"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "{pt} > 40"
+        - "{pt} < 100"
+      object:
+        - "abs({eta}) < 5"
+  test_objects:
+    seededConePuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone PuppiJet"
+      cuts:
+        - "abs({eta}) < 5"
+    seededConeExtendedPuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+        - "abs({eta}) < 5"
+  xlabel: "Gen. $\\eta$"
+  ylabel: "Matching Efficiency (40-100 GeV)"
+  binning:
+    min: -5
+    max: 5
+    step: 0.25
+
+JetMatching_Eta_Pt100ToInf_ExtendedVsRegular:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Eta"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "{pt} > 100"
+      object:
+        - "abs({eta}) < 5"
+  test_objects:
+    seededConePuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+    seededConeExtendedPuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+  xlabel: "Gen. $\\eta$"
+  ylabel: "Matching Efficiency (>100 GeV)"
+  binning:
+    min: -5
+    max: 5
+    step: 0.25
+
+JetMatching_Eta_Pt30ToInf_genBJets:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Eta"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "{pt} > 30"
+        - "abs({partonflavour}) == 5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    seededConeExtendedPuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+       - "{bjetnn}>0.71"
+  xlabel: "Gen. $\\eta$"
+  ylabel: "Matching Efficiency (>30 GeV)"
+  # thresholds: [0.0,0.5,0.7,0.71,0.72]
+  binning:
+    min: -2.4
+    max: 2.4
+    step: 0.25
+
+JetMatching_Eta_Pt30ToInf_genNotBJets:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Eta"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "{pt} > 30"
+        - "abs({partonflavour}) != 5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    seededConeExtendedPuppiJet:
+      match_dR: 0.35
+      suffix: "Eta"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+       - "{bjetnn}>0.71"
+  xlabel: "Gen. $\\eta$"
+  ylabel: "Matching Efficiency (>30 GeV)"
+  # thresholds: [0.0,0.5,0.7,0.71,0.72]
+  binning:
+    min: -2.4
+    max: 2.4
+    step: 0.25
+
+JetMatching_Pt_Pt30ToInf_genBJets:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Pt"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "abs({partonflavour}) == 5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    seededConeExtendedPuppiJet:
+      match_dR: 0.4
+      suffix: "Pt"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+       - "{bjetnn}>0.71"
+  xlabel: "Gen. $p_T$ (GeV)"
+  ylabel: "Matching Efficiency"
+  # thresholds: [-999,0,0.5,0.68,0.71,0.74,0.9]
+  # thresholds: [0.0,0.5,0.7,0.71,0.72]
+  binning:
+    min: 30
+    max: 200
+    step: 10
+
+JetMatching_Pt_Pt30ToInf_genNotBJets:
+  sample: TT
+  default_version: V27
+  reference_object: 
+    object: "jet"
+    suffix: "Pt"
+    label: "Gen Jets"
+    cuts:
+      event:
+        - "abs({partonflavour}) != 5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    seededConeExtendedPuppiJet:
+      match_dR: 0.35
+      suffix: "Pt"
+      label: "Seeded Cone Extended PuppiJet"
+      cuts:
+       - "abs({eta}) < 5"
+       - "{bjetnn}>0.71"
+  xlabel: "Gen. $p_T$ (GeV)"
+  ylabel: "Matching Efficiency"
+  # thresholds: [0.0,0.5,0.7,0.71,0.72]
+  binning:
+    min: 30
+    max: 200
+    step: 10

--- a/objectPerformance/src/plotBTagEfficiency.py
+++ b/objectPerformance/src/plotBTagEfficiency.py
@@ -1,0 +1,98 @@
+#!/afs/cern.ch/user/d/dhundhau/public/miniconda3/envs/py310/bin/python
+import argparse
+import os
+
+import matplotlib.pyplot as plt
+import mplhep as hep
+import numpy as np
+import yaml
+import json
+
+from plotter import Plotter
+
+plt.style.use(hep.style.CMS)
+
+
+class ComparisonCentral(Plotter):
+
+    def __init__(self, cfg_plots_path):
+        with open(cfg_plots_path, 'r') as f:
+            self.cfg_plots = yaml.safe_load(f)
+        self.cfgs = {}
+        for plot_name, cfg_plot in self.cfg_plots.items():
+            print (plot_name)
+            self.cfgs[plot_name] = cfg_plot
+            if not os.path.exists(cfg_plot['save_dir']): os.makedirs(cfg_plot['save_dir'])
+            # self.plot_name = plot_name
+        # self.cfg = self.cfg_plots[self.plot_name]
+        # self.save_dir = self.cfg["save_dir"]
+        # if not os.path.exists(self.save_dir): os.makedirs(self.save_dir)
+
+    def _get_watermark(self,cfg):
+       try:
+           return cfg["watermark"]
+       except KeyError:
+           return " "
+
+    def _get_files(self,cfg):
+        try:
+            return cfg["files"]
+        except KeyError:
+            print("You must specify the input files under the key 'files'!")
+
+    def _get_plot(self, name):
+        fname = open(name + ".json")
+        dict_to_plot = json.load(fname)
+        return dict_to_plot
+
+    def _style_plot(self, cfg, fig, ax, legend_loc="upper right"):
+        ax.axhline(1, ls=":", c="k")
+        ax.legend(loc=legend_loc, frameon=False)
+        ax.set_xlabel(rf"{cfg['xlabel']}")
+        ylabel = cfg["ylabel"]
+        ax.set_ylabel(rf"{ylabel}")
+        ax.set_ylim(0.0, 1)
+        ax.tick_params(direction="in")
+        ax.text(0, -0.1, self._get_watermark(cfg),
+                color="grey", alpha=0.2,
+                fontsize=20,
+                transform=ax.transAxes)
+        fig.tight_layout()
+
+    def run(self):
+        for plot_name, cfg in self.cfgs.items():
+            files = self._get_files(cfg)
+            fig, ax =  self._create_new_plot()
+            for file in files:
+                fname = os.path.join(files[file]["dir"], file)
+                test_object = files[file]["object"]
+                dict_to_plot = self._get_plot(fname)
+
+                label = dict_to_plot[test_object]["label"]
+                if "label" in files[file]:
+                    label = files[file]["label"]
+
+                err_kwargs = dict_to_plot[test_object]["err_kwargs"]
+
+                ax.errorbar(dict_to_plot[test_object]["xbins"],
+                            dict_to_plot[test_object]["efficiency"],
+                            yerr = dict_to_plot[test_object]["efficiency_err"],
+                            label = label, **err_kwargs)
+
+            self._style_plot(cfg, fig, ax)
+            print ("Saving plot to : ",plot_name)
+            plt.savefig(f"{cfg['save_dir']}/{plot_name}.png")
+            plt.savefig(f"{cfg['save_dir']}/{plot_name}.pdf")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "cfg_plots",
+        default="cfg_plots/bJetEff.yaml",
+        help="Path of YAML file specifying the desired plots."
+    )
+    args = parser.parse_args()
+
+    plotter = ComparisonCentral(args.cfg_plots)
+    plotter.run()
+


### PR DESCRIPTION
- Added cache and plotting configs for producing b/mis tag plots
- Cache config picks up both seeded cone jet collections from ntuples
- The "extended" seeded cone jets (those produced with extended tracks) are the ones with the b jet NN defined
- The plotting config produces "standard" matching plots for the two seeded cone jet collections just to check the performance of the two are similar (before any b tagging).
- The plotting config also produces b/mis tag efficiency plots vs pt and eta for a working point (cut on b jet NN) that gives a mistag rate of ~10% in a ttbar+200PU sample
- Added a script `plotBTagEfficiency.py` and config `bJetEff.yaml` to overlay the b/mis tag efficiencies on the same plot - example below.

![BJetEff_Pt](https://user-images.githubusercontent.com/4438699/230120144-e92a9bfe-cd10-4f02-913e-27f8fc3ebbfe.png)

The plots above include the jet reconstruction efficiency (i.e. efficiency for a gen b jet to be reconstructed as a seeded cone jet and pass the NN cut).  It wasn't clear to me how to produce efficiency plots for just the NN cut with these tools (i.e. the denominator are generator jets matched to seeded cone jets).  I think this is essentially what is done when plotting the turn on curves, but with a cut on the L1 pt instead of the b jet NN.  I may have hacked the tools to produce this plot (not in this PR), but I hope there's a better/official way of doing this.

@artlbv 