### PR TITLE
[Menu] Fix DoubleMu 15,7 seed leg2 threshold and quality

### DIFF
--- a/rates/table/cfg/v29/v29_16Seeds_Final
+++ b/rates/table/cfg/v29/v29_16Seeds_Final
@@ -191,7 +191,7 @@ function :: GMTTkMuonOfflineEtCut :: args:=(offline,Et,Eta); lambda:=Et>offline 
 trigger  :: L1_SingleTkMu     :: leg1:=(tkGmtMu  , GMTTkMuonOfflineEtCut(22.0,Pt,Eta), abs(Eta)<2.4 ); \
 
 trigger  :: L1_DoubleTkMu     :: leg1:=(tkGmtMu   , GMTTkMuonOfflineEtCut(15.0,Pt,Eta), abs(Eta)<2.4); \
-				                 leg2:=(tkGmtMu   , GMTTkMuonOfflineEtCut(7.0,Pt,Eta), abs(Eta)<2.4, abs(leg1.Z0-Z0)<1); \
+				                 leg2:=(tkGmtMu   , Pt > 7, abs(Eta)<2.4, abs(leg1.Z0-Z0)<1, Qual > 0); \
 
 trigger  :: L1_TripleTkMu    :: leg1:=(tkGmtMu, Pt>5, abs(Eta)<2.4, Qual>0 ); \
                                 leg2:=(tkGmtMu, Pt>3, abs(Eta)<2.4, abs(Z0-leg1.Z0)<1, Qual>0 ); \

--- a/rates/table/cfg/v29/v29_NOMUONS_Final
+++ b/rates/table/cfg/v29/v29_NOMUONS_Final
@@ -191,7 +191,7 @@ function :: GMTTkMuonOfflineEtCut :: args:=(offline,Et,Eta); lambda:=Et>offline 
 trigger  :: L1_SingleTkMu     :: leg1:=(tkGmtMu  , GMTTkMuonOfflineEtCut(22.0,Pt,Eta), abs(Eta)<2.4 ); \
 
 trigger  :: L1_DoubleTkMu     :: leg1:=(tkGmtMu   , GMTTkMuonOfflineEtCut(15.0,Pt,Eta), abs(Eta)<2.4); \
-				                 leg2:=(tkGmtMu   , GMTTkMuonOfflineEtCut(7.0,Pt,Eta), abs(Eta)<2.4, abs(leg1.Z0-Z0)<1); \
+								 leg2:=(tkGmtMu   , Pt > 7, abs(Eta)<2.4, abs(leg1.Z0-Z0)<1, Qual > 0); \
 
 # trigger  :: L1_TripleTkMu    :: leg1:=(tkGmtMu, Pt>5, abs(Eta)<2.4, Qual>0 ); \
 #                                 leg2:=(tkGmtMu, Pt>3, abs(Eta)<2.4, abs(Z0-leg1.Z0)<1, Qual>0 ); \

--- a/rates/table/cfg/v29/v29_WITHMUONS_Final
+++ b/rates/table/cfg/v29/v29_WITHMUONS_Final
@@ -191,7 +191,7 @@ function :: GMTTkMuonOfflineEtCut :: args:=(offline,Et,Eta); lambda:=Et>offline 
 trigger  :: L1_SingleTkMu     :: leg1:=(tkGmtMu  , GMTTkMuonOfflineEtCut(22.0,Pt,Eta), abs(Eta)<2.4 ); \
 
 trigger  :: L1_DoubleTkMu     :: leg1:=(tkGmtMu   , GMTTkMuonOfflineEtCut(15.0,Pt,Eta), abs(Eta)<2.4); \
-				                 leg2:=(tkGmtMu   , GMTTkMuonOfflineEtCut(7.0,Pt,Eta), abs(Eta)<2.4, abs(leg1.Z0-Z0)<1); \
+				                 leg2:=(tkGmtMu   , Pt > 7, abs(Eta)<2.4, abs(leg1.Z0-Z0)<1, Qual > 0); \
 
 trigger  :: L1_TripleTkMu    :: leg1:=(tkGmtMu, Pt>5, abs(Eta)<2.4, Qual>0 ); \
                                 leg2:=(tkGmtMu, Pt>3, abs(Eta)<2.4, abs(Z0-leg1.Z0)<1, Qual>0 ); \


### PR DESCRIPTION
To uniformise the gmtTkMuon usage for < 8 GeV thresholds we change the DoubleMu 15,7 2nd leg accordingly: use online threshold 7 and `quality > 0`.