### PR TITLE
add gmtMuon quality cut in overlap region

### DIFF
--- a/configs/V29/objects/muons.yaml
+++ b/configs/V29/objects/muons.yaml
@@ -7,7 +7,10 @@ gmtMuon:
     overlap: [0.83, 1.24]
     endcap: [1.24, 2.4]
   ids:
-    default: {}
+    default:
+      cuts:
+        overlap:
+          - "{quality} >= 12"
 
 gmtTkMuon:
   label: "GMT TkMuon"


### PR DESCRIPTION
- add gmtMuon quality cut in overlap region motivated by discrepancies in the rate plot comp with old tools