### PR TITLE
Post AR24 fixes: fix tkElectron ID

### DIFF
--- a/configs/V32/objects/electrons.yaml
+++ b/configs/V32/objects/electrons.yaml
@@ -28,8 +28,10 @@ tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.7"
-        barrel:
+        endcap:
           - "({passeseleid} == 1) | ({pt} < 25)"
+        barrel:
+          - "{passeseleid} == 1"
     Iso:
       label: "TkIsoElectron"
       cuts:
@@ -37,7 +39,6 @@ tkElectron:
           - "abs({eta}) < 2.4"
         barrel:
           - "abs({trkiso}) < 0.13"
-          - "({passeseleid} == 1) | ({pt} < 25)"
         endcap:
           - "abs({trkiso}) < 0.28"
     IsoNoIDinEE:

--- a/configs/V32nano/caching.yaml
+++ b/configs/V32nano/caching.yaml
@@ -40,9 +40,10 @@ V32nano:
       Events:
         GenVisTau: "all" 
         L1nnTau: "all" 
-        L1hpsTau: "all" 
+        L1GTnnTau: "all" 
+        # L1hpsTau: "all" 
         L1caloTau: "all" 
-        L1nnCaloTau: "all"
+        # L1nnCaloTau: "all"
   MinBias:
     ntuple_path: 
     trees_branches:

--- a/configs/V32nano/object_performance/jets_trigger.yaml
+++ b/configs/V32nano/object_performance/jets_trigger.yaml
@@ -17,9 +17,9 @@ JetTurnonBarrel:
     L1caloJet:default: "pt"
     # trackerJet:default:barrel: "pt"
   thresholds: [50, 100]
-  scalings:
-    method: "naive"
-    threshold: 0.95
+  # scalings:
+  #   method: "naive"
+  #   threshold: 0.95
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV, barrel)"
   binning:
@@ -46,9 +46,9 @@ JetTurnonEndcap:
     L1caloJet:default: "pt"
     # trackerJet:default:endcap: "pt"
   thresholds: [50, 100]
-  scalings:
-    method: "naive"
-    threshold: 0.95
+  # scalings:
+  #   method: "naive"
+  #   threshold: 0.95
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV, endcap)"
   binning:

--- a/configs/V32nano/object_performance/muon_matching_eta.yaml
+++ b/configs/V32nano/object_performance/muon_matching_eta.yaml
@@ -1,4 +1,4 @@
-MuonsMatching_Eta_pt2to5:
+MuonsMatching_Eta_Pt2to5:
   sample: DYLL_M50
   version: V32nano
   match_test_to_ref: True
@@ -24,7 +24,7 @@ MuonsMatching_Eta_pt2to5:
     max: 3
     step: 0.2
 
-MuonsMatching_Eta_pt15toInf:
+MuonsMatching_Eta_Pt15toInf:
   sample: DYLL_M50
   version: V32nano
   match_test_to_ref: True

--- a/configs/V32nano/object_performance/tau_matching.yaml
+++ b/configs/V32nano/object_performance/tau_matching.yaml
@@ -14,10 +14,10 @@ TausMatchingBarrel:
         - "abs({eta}) < 2.4"
   test_objects:
     L1nnTau:default: "pt"
-    L1hpsTau:default: "pt"
+    # L1hpsTau:default: "pt"
     L1caloTau:default: "pt"
-    L1nnCaloTau:default: "pt"
-    L1caloTau:PtGe20: "Pt"
+    # L1nnCaloTau:default: "pt"
+    # L1caloTau:PtGe20: "Pt"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Barrel)"
   binning:
@@ -41,10 +41,10 @@ TausMatchingEndcap:
         - "abs({eta}) < 2.4"
   test_objects:
     L1nnTau:default: "pt"
-    L1hpsTau:default: "pt"
+    # L1hpsTau:default: "pt"
     L1caloTau:default: "pt"
-    L1nnCaloTau:default: "pt"
-    L1caloTau:PtGe20: "Pt"
+    # L1nnCaloTau:default: "pt"
+    # L1caloTau:PtGe20: "Pt"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Endcap)"
   binning:

--- a/configs/V32nano/objects/electrons.yaml
+++ b/configs/V32nano/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V33nano/objects/electrons.yaml
+++ b/configs/V33nano/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V34nano/objects/electrons.yaml
+++ b/configs/V34nano/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V35nano_ModTT/objects/electrons.yaml
+++ b/configs/V35nano_ModTT/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V36nano_noTT/objects/electrons.yaml
+++ b/configs/V36nano_noTT/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V37nano/objects/electrons.yaml
+++ b/configs/V37nano/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V38nano/objects/electrons.yaml
+++ b/configs/V38nano/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:

--- a/configs/V38nano_DT12x/objects/electrons.yaml
+++ b/configs/V38nano_DT12x/objects/electrons.yaml
@@ -10,14 +10,17 @@ L1tkElectron:
       cuts:
         inclusive:
           - "abs({eta}) < 2.4"
+        endcap:
           - "({eleId} == 1) | ({pt} < 25)"
+        barrel:
+          - "{eleId} == 1"
     NoIsoForIso:
       # This id is exclusively used for the
       # isoloation wp derivation
       label: "TkElectron, no ID"
       cuts:
         inclusive:
-          - "abs({eta}) < 2.7"
+          - "abs({eta}) < 2.4"
     Iso:
       label: "TkIsoElectron"
       cuts:


### PR DESCRIPTION
Fixing the tkElectron ID starting from V32 to comply with what was agreed with EGamma and written in the twiki:
https://twiki.cern.ch/twiki/bin/view/CMS/PhaseIIL1TriggerMenuTools#Definitions_of_objects_and_scali